### PR TITLE
Setup pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+before_install:
+  - "bash travis-output.sh"
 install:
   - "pip install ."
   - "pip install flake8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: python
 python:
   - "3.6"
 before_install:
-  - "pip install -U sphinx"
-  - "bash travis-output.sh"
+  - "pip install sphinxcontrib-napoleon"
 install:
+  - "bash travis-output.sh"
   - "pip install flake8"
 script:
   - "flake8 ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ install:
   - "pip install flake8"
 script:
   - "flake8 ."
+  - "pytest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
 before_install:
   - "bash travis-output.sh"
 install:
-  - "pip install ."
   - "pip install flake8"
 script:
   - "flake8 ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
 install:
+  - "pip install ."
   - "pip install flake8"
 script:
   - "flake8 ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
 before_install:
+  - "pip install -U sphinx"
   - "bash travis-output.sh"
 install:
   - "pip install flake8"

--- a/tests/test_gan.py
+++ b/tests/test_gan.py
@@ -1,0 +1,11 @@
+"""
+Test suite for GAN network.
+"""
+import pytest
+from cortex.built_ins.models.gan import raise_measure_error
+
+
+def test_raise_measure_error():
+    measure = 'X'
+    with pytest.raises(NotImplementedError):
+        raise_measure_error(measure)

--- a/travis-output.sh
+++ b/travis-output.sh
@@ -28,7 +28,7 @@ PING_LOOP_PID=$!
 # My build is using maven, but you could build anything with this, E.g.
 # your_build_command_1 >> $BUILD_OUTPUT 2>&1
 # your_build_command_2 >> $BUILD_OUTPUT 2>&1
-mvn clean install >> $BUILD_OUTPUT 2>&1
+pip install . >> $BUILD_OUTPUT 2>&1
 
 # The build finished without returning an error so dump a tail of the output
 dump_output

--- a/travis-output.sh
+++ b/travis-output.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Abort on Error
+set -e
+
+export PING_SLEEP=30s
+export WORKDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export BUILD_OUTPUT=$WORKDIR/build.out
+
+touch $BUILD_OUTPUT
+
+dump_output() {
+   echo Tailing the last 500 lines of output:
+   tail -500 $BUILD_OUTPUT
+}
+error_handler() {
+  echo ERROR: An error was encountered with the build.
+  dump_output
+  exit 1
+}
+# If an error occurs, run our error handler to output a tail of the build
+trap 'error_handler' ERR
+
+# Set up a repeating loop to send some output to Travis.
+
+bash -c "while true; do echo \$(date) - building ...; sleep $PING_SLEEP; done" &
+PING_LOOP_PID=$!
+
+# My build is using maven, but you could build anything with this, E.g.
+# your_build_command_1 >> $BUILD_OUTPUT 2>&1
+# your_build_command_2 >> $BUILD_OUTPUT 2>&1
+mvn clean install >> $BUILD_OUTPUT 2>&1
+
+# The build finished without returning an error so dump a tail of the output
+dump_output
+
+# nicely terminate the ping output loop
+kill $PING_LOOP_PID


### PR DESCRIPTION
Running `pytest` locally is correctly running the test suite, but integration with Travis-CI doesn't work, as it can not find the Cortex module. 

`E   ModuleNotFoundError: No module named 'cortex'`

Issue #130 has been open. 