### PR TITLE
Removes parenthesis of backups names.

### DIFF
--- a/cortex/_lib/exp.py
+++ b/cortex/_lib/exp.py
@@ -9,8 +9,8 @@ import os
 from os import path
 from shutil import copyfile, rmtree
 import yaml
-
 import torch
+import re
 
 from .log_utils import set_file_logger
 from .parsing import update_args
@@ -91,6 +91,7 @@ def reload(model, exp_file, reloads, name, out_path, clean, config):
 
 def save(model, prefix=''):
     prefix = _file_string(prefix)
+    prefix = re.sub(r'\([^)]*\)', '', prefix)
     binary_dir = OUT_DIRS.get('binary_dir', None)
     if binary_dir is None:
         return


### PR DESCRIPTION
Removes parenthesis when saving .t7 file to avoid error when reloading a model.